### PR TITLE
Support extends in codegen and templates, refactoring

### DIFF
--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/ModelPropertyProcessor.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/ModelPropertyProcessor.kt
@@ -258,9 +258,16 @@ open class ModelPropertyProcessor(val codegen: CodeCodegen) {
 		val innerModel = codegen.fromModel(realType, innerModelSchema)
 		if (innerModel.vendorExtensions["isEmbeddable"] == true) {
 			assignEmbeddedModel(property, innerModel, true)
+		} else if(property.name == "_extends") {
+			assignExtendsModel(property, innerModel)
 		} else { // assign one-to-one relationship if not isEmbeddable model (has id)
 			property.vendorExtensions["isOneToOne"] = true
 		}
+	}
+
+	private fun assignExtendsModel(property: CodegenProperty, innerModel: CodegenModel) {
+		property.vendorExtensions["extendsComponent"] = innerModel
+		property.vendorExtensions["isExtends"] = true
 	}
 
 	private fun isInnerModel(property: CodegenProperty): Boolean {

--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/OptsImportMappings.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/OptsImportMappings.kt
@@ -31,7 +31,7 @@ class OptsImportMappings(val codegen: CodeCodegen) {
 			"BigDecimal" to "java.math.BigDecimal",
 			"MetaDataAnnotation" to "MetaDataAnnotation",
 			"Guid" to "?.annotations.Guid",
-			"BaseResource" to "$basePackage.domain.BaseResource",
+//			"BaseResource" to "$basePackage.domain.BaseResource",
 			"BaseDomain" to "$basePackage.domain.BaseDomain",
 			"JsonType" to "org.hibernate.annotations.Type",
 			"JsonIgnore" to "com.fasterxml.jackson.annotation.JsonIgnore"

--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/OptsPostProcessor.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/OptsPostProcessor.kt
@@ -100,6 +100,12 @@ class OptsPostProcessor(val codegen: CodeCodegen) {
 		val appPackage = additionalProperties["appPackage"]
 		val appName = additionalProperties["appRealName"]
 
+		val openApiWrapper = OpenApiWrapper(codegen)
+		val hasEntityBlocks = openApiWrapper.isOpenApiContainsType("Entity")
+		val hasIdentityBlocks = openApiWrapper.isOpenApiContainsType("Identity")
+		additionalProperties["hasEntityBlocks"] = hasEntityBlocks
+		additionalProperties["hasIdentityBlocks"] = hasIdentityBlocks
+
 
 		val inputSrcRoot = "$inputAppRoot/src/main/kotlin"
 		val inputResRoot = "$inputAppRoot/src/main/resources"
@@ -184,14 +190,18 @@ class OptsPostProcessor(val codegen: CodeCodegen) {
 		addSupportFile(source = "$inputSrc/controller/AbstractController.kt.mustache", folder = "$destSrc/controller", target = "AbstractController.kt")
 		addSupportFile(source = "$inputSrc/controller/CommonController.kt.mustache", folder = "$destSrc/controller", target = "CommonController.kt")
 		addSupportFile(source = "$inputSrc/controller/CommonParameterizedController.kt.mustache", folder = "$destSrc/controller", target = "CommonParameterizedController.kt")
-		addSupportFile(source = "$inputSrc/domain/BaseResource.kt.mustache", folder = "$destSrc/domain", target = "BaseResource.kt")
-		addSupportFile(source = "$inputSrc/domain/BaseDomain.kt.mustache", folder = "$destSrc/domain", target = "BaseDomain.kt")
+		if (!OpenApiWrapper(codegen).isOpenApiContainsType("BaseResource")) {
+			addSupportFile(source = "$inputSrc/listener/BaseResourceListener.kt.mustache", folder = "$destSrc/listener", target = "BaseResourceListener.kt")
+			addSupportFile(source = "$inputSrc/domain/BaseResource.kt.mustache", folder = "$destSrc/domain", target = "BaseResource.kt")
+		}
+		if (!OpenApiWrapper(codegen).isOpenApiContainsType("BaseDomain")) {
+			addSupportFile(source = "$inputSrc/domain/BaseDomain.kt.mustache", folder = "$destSrc/domain", target = "BaseDomain.kt")
+		}
 //		addSupportFile(source = "$inputSrc/domain/ResourceEntity.kt.mustache", folder = "$destSrc/domain", target = "ResourceEntity.kt")
 //		addSupportFile(source = "$inputSrc/domain/History.kt.mustache", folder = "$destSrc/domain", target = "History.kt")
 //		addSupportFile(source = "$inputSrc/domain/Identity.kt.mustache", folder = "$destSrc/domain", target = "Identity.kt")
 		addSupportFile(source = "$inputSrc/exception/InvalidRequestException.kt.mustache", folder = "$destSrc/exception", target = "InvalidRequestException.kt")
 		addSupportFile(source = "$inputSrc/exception/ResourceNotFoundException.kt.mustache", folder = "$destSrc/exception", target = "ResourceNotFoundException.kt")
-		addSupportFile(source = "$inputSrc/listener/BaseResourceListener.kt.mustache", folder = "$destSrc/listener", target = "BaseResourceListener.kt")
 		addSupportFile(source = "$inputSrc/listener/BaseDomainListener.kt.mustache", folder = "$destSrc/listener", target = "BaseDomainListener.kt")
 		addSupportFile(source = "$inputSrc/repository/CommonRepository.kt.mustache", folder = "$destSrc/repository", target = "CommonRepository.kt")
 		addSupportFile(source = "$inputSrc/service/AbstractService.kt.mustache", folder = "$destSrc/service", target = "AbstractService.kt")

--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/models/CommonModelsProcessor.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/models/CommonModelsProcessor.kt
@@ -1,6 +1,7 @@
 package pro.bilous.codegen.process.models
 
 import org.openapitools.codegen.CodegenModel
+import pro.bilous.codegen.utils.SuperclassRegistry
 
 class CommonModelsProcessor(val properties: MutableMap<String, Any>) {
 
@@ -11,7 +12,7 @@ class CommonModelsProcessor(val properties: MutableMap<String, Any>) {
 	}
 
 	fun process(model: CodegenModel) {
-		if (!commonModelNames.contains(model.name)) {
+		if (!isCommonModel(model.name)) {
 			return
 		}
 		val commonModels = if (properties.containsKey("commonModels")) {
@@ -31,6 +32,10 @@ class CommonModelsProcessor(val properties: MutableMap<String, Any>) {
 		fixProperties(model)
 	}
 
+	private fun isCommonModel(name: String): Boolean {
+		return commonModelNames.contains(name) || SuperclassRegistry.hasName(name)
+	}
+
 	private fun fixProperties(model: CodegenModel) {
 		if (model.classname == "ResourceEntity") {
 			model.vendorExtensions["addEntityIdVar"] = true
@@ -48,7 +53,7 @@ class CommonModelsProcessor(val properties: MutableMap<String, Any>) {
 		}
 		// quick fix for the identity and entity
 		when (model.classname) {
-			"ResourceEntity", "Identity", "History" -> {
+			"ResourceEntity", "Identity", "History", "BaseResource" -> {
 				model.vars.forEach {
 					if (it.required) {
 						it.required = false
@@ -75,7 +80,7 @@ class CommonModelsProcessor(val properties: MutableMap<String, Any>) {
 	}
 
 	fun canResolveImport(modelName: String): Boolean {
-		if (commonModelNames.contains(modelName)) {
+		if (commonModelNames.contains(modelName) || SuperclassRegistry.hasName(modelName)) {
 			return true
 		}
 		if (!properties.containsKey("commonModels")) {

--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/models/IModelStrategyResolver.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/models/IModelStrategyResolver.kt
@@ -1,0 +1,8 @@
+package pro.bilous.codegen.process.models
+
+interface IModelStrategyResolver {
+	fun resolveParent(args: ModelStrategyResolver.Args)
+	fun cleanupImports()
+	fun buildArgs(): ModelStrategyResolver.Args
+	fun addExtensions(args: ModelStrategyResolver.Args)
+}

--- a/codegen-cli/src/main/java/pro/bilous/codegen/process/models/ModelStrategyResolver.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/process/models/ModelStrategyResolver.kt
@@ -1,0 +1,82 @@
+package pro.bilous.codegen.process.models
+
+import com.google.common.base.CaseFormat
+import org.openapitools.codegen.CodegenModel
+import pro.bilous.codegen.utils.SuperclassRegistry
+
+class ModelStrategyResolver(val model: CodegenModel) : IModelStrategyResolver {
+
+	companion object {
+		val importsToIgnore = arrayOf(
+			"ApiModel", "ApiModelProperty", "JsonProperty", "Entity", "ResourceEntity", "Identity", "Property"
+		)
+	}
+
+	override fun resolveParent(args: Args) {
+		val extensions = model.vendorExtensions
+		when {
+			args.hasEntity -> {
+				val parent = "BaseResource()"
+				model.parent = parent
+				model.imports.add("BaseResource")
+
+				model.vars = model.vars.filter { "identity" != it.name && "entity" != it.name }
+				extensions["hasTableEntity"] = true
+			}
+			args.hasId -> {
+				model.parent = "BaseDomain()"
+				model.imports.add("BaseDomain")
+				model.vars = model.vars.filter { "id" != it.name && "identity" != it.name }
+			}
+			args.hasIdentity -> {
+				model.parent = "BaseDomain()"
+				model.imports.add("BaseDomain")
+				// we are unable to support identity for now. So, just remove the field and add ID instead of it.
+				model.vars = model.vars.filter { "id" != it.name && "identity" != it.name }
+			}
+			args.hasExtends -> {
+				val extendProperty = model.requiredVars.find { it.name == "_extends" }!!
+				val parentType = extendProperty.complexType
+				model.parent = "${parentType}()"
+				model.imports.add(parentType)
+			}
+		}
+	}
+
+	override fun cleanupImports() {
+		importsToIgnore.forEach {
+			model.imports.remove(it)
+		}
+	}
+
+	override fun buildArgs(): Args {
+		return Args(
+			hasEntity = model.vars.any { "entity" == it.name.toLowerCase() },
+			hasIdentity = model.vars.any { "identity" == it.name.toLowerCase() },
+			hasId = model.vars.any { "id" == it.name.toLowerCase() } && model.name != "Identity",
+			hasExtends = model.requiredVars.any { "_extends" == it.name.toLowerCase() }
+		)
+	}
+
+	override fun addExtensions(args: Args) {
+		val extensions = model.vendorExtensions
+		if (!args.hasEntity && args.hasIdentity) {
+			extensions["hasTableEntity"] = false
+		}
+		val tableName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, model.name)
+		extensions["tableName"] = tableName
+		extensions["isEmbeddable"] = !args.hasEntity && !args.hasIdentity && !args.hasId && !args.hasExtends
+		extensions["addIdVar"] = false // !hasEntity && hasIdentity
+		val isSuperclass = SuperclassRegistry.hasName(model.name)
+		extensions["isSuperclass"] = isSuperclass
+		extensions["hasIdentity"] = args.hasIdentity
+		extensions["hasEntity"] = args.hasEntity
+	}
+
+	data class Args(
+		val hasEntity: Boolean = false,
+		val hasIdentity: Boolean = false,
+		val hasId: Boolean = false,
+		val hasExtends: Boolean = false
+	)
+}

--- a/codegen-cli/src/main/java/pro/bilous/codegen/utils/SuperclassRegistry.kt
+++ b/codegen-cli/src/main/java/pro/bilous/codegen/utils/SuperclassRegistry.kt
@@ -1,0 +1,9 @@
+package pro.bilous.codegen.utils
+
+object SuperclassRegistry {
+	val modelNames = setOf("BaseResource")
+
+	fun hasName(name: String): Boolean {
+		return modelNames.contains(name)
+	}
+}

--- a/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/main/resources/liquibase/migrations/changeLog.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/main/resources/liquibase/migrations/changeLog.mustache
@@ -8,6 +8,7 @@
 {{#models}}
 	{{#model}}
 	{{^vendorExtensions.isEmbeddable}}
+	{{^vendorExtensions.isSuperclass}}
 	<changeSet author="CodeGeneration" id="create_generated_table_{{vendorExtensions.tableName}}">
 		<preConditions onFail="MARK_RAN">
 			<not>
@@ -29,6 +30,15 @@
 			<column name="name" type="VARCHAR(255)"/>
 			<column name="description" type="VARCHAR(510)"/>
 			{{/vendorExtensions.hasTableEntity}}
+			{{#allVars}}
+				{{#vendorExtensions.isExtends}}
+					{{#vendorExtensions.extendsComponent}}
+						{{#vars}}
+			<column name="{{vendorExtensions.columnName}}" type="{{vendorExtensions.columnType}}"/>
+						{{/vars}}
+					{{/vendorExtensions.extendsComponent}}
+				{{/vendorExtensions.isExtends}}
+			{{/allVars}}
 			{{#vars}}
 			{{#vendorExtensions.hasJsonType}}
 			<column name="{{vendorExtensions.columnName}}" type="{{vendorExtensions.columnType}}"/>
@@ -63,6 +73,7 @@
 			{{/vars}}
 		</createTable>
 	</changeSet>
+	{{/vendorExtensions.isSuperclass}}
 	{{/vendorExtensions.isEmbeddable}}
 	{{/model}}
 {{/models}}

--- a/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/test/kotlin/controller/apiTest.kt.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/test/kotlin/controller/apiTest.kt.mustache
@@ -5,7 +5,9 @@ package {{appPackage}}.controller
 {{#testImports}}import {{import}}
 {{/testImports}}
 {{#hasPathParent}}
+	{{#testModel.vendorExtensions.hasIdentity}}
 import {{basePackage}}.domain.Identity
+	{{/testModel.vendorExtensions.hasIdentity}}
 {{/hasPathParent}}
 import {{appPackage}}.{{appRealName}}Application
 import {{appPackage}}.repository.{{repositoryClassname}}
@@ -39,14 +41,26 @@ class {{classname}}IT : AbstractIntegrationTest<{{returnEntityType}}>() {
 	private fun resourceAsserts(savedResource: {{returnEntityType}}, result: MvcResult, index: Int = -1) {
 		val prefix = if (index == -1) "$" else "$.content[$index]"
 		if (savedResource.id != null) {
+		{{#vendorExtensions.hasIdentity}}
 			assertEquals(savedResource.id, getValue(result, "$prefix.identity.id"))
+		{{/vendorExtensions.hasIdentity}}
+		{{^vendorExtensions.hasIdentity}}
+			assertEquals(savedResource.id, getValue(result, "$prefix.id"))
+		{{/vendorExtensions.hasIdentity}}
 		} else {
+		{{#vendorExtensions.hasIdentity}}
 			assertNotNull(getValue(result, "$prefix.identity.id"))
+		{{/vendorExtensions.hasIdentity}}
+		{{^vendorExtensions.hasIdentity}}
+			assertNotNull(getValue(result, "$prefix.id"))
+		{{/vendorExtensions.hasIdentity}}
 		}
+		{{#testModel}}
+		{{#vendorExtensions.hasIdentity}}
 		assertEquals(savedResource.identity.name, getValue(result, "$prefix.identity.name"))
 		assertEquals(savedResource.identity.description, getValue(result, "$prefix.identity.description"))
 		assertEquals(savedResource.entity.state, getValue(result, "$prefix.entity.state"))
-		{{#testModel}}
+		{{/vendorExtensions.hasIdentity}}
 		{{#vars}}
 		{{^isListContainer}}
 		{{#vendorExtensions.hasTestModel}}
@@ -80,14 +94,14 @@ class {{classname}}IT : AbstractIntegrationTest<{{returnEntityType}}>() {
 				{{/required}}
 				{{/vars}}
 			{{/testModel}}
-		).apply {
+		){{#testModel.vendorExtensions.hasIdentity}}.apply {
 			this.identity.name = "test name"
 			this.identity.description = "test description"
 			this.entity.state = "active"
 			{{#hasPathParent}}
 			this.entity.parent = Identity(id = "parent-id")
 			{{/hasPathParent}}
-		}
+		}{{/testModel.vendorExtensions.hasIdentity}}
 	}
 
 	private fun createWithAllFields(): {{returnEntityType}} {
@@ -97,14 +111,14 @@ class {{classname}}IT : AbstractIntegrationTest<{{returnEntityType}}>() {
 				{{>app-module/src/test/kotlin/controller/apiTestVar}}{{#hasMore}},{{/hasMore}}
 				{{/vars}}
 			{{/testModel}}
-		).apply {
+		){{#testModel.vendorExtensions.hasIdentity}}.apply {
 			this.identity.name = "test user name"
 			this.identity.description = "test user description"
 			this.entity.state = "active"
 			{{#hasPathParent}}
 			this.entity.parent = Identity(id = "parent-id")
 			{{/hasPathParent}}
-		}
+		}{{/testModel.vendorExtensions.hasIdentity}}
 	}
 
 }

--- a/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/test/kotlin/controller/apiTestMethod.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/test/kotlin/controller/apiTestMethod.mustache
@@ -22,7 +22,7 @@
 		val res = createWithRequiredFields()
 		val savedRes = repository.save(res)
 
-		val result = super.getById(url, savedRes.identity.id!!)
+		val result = super.getById(url, savedRes.id!!)
 		resourceAsserts(savedRes, result)
 	}
 
@@ -31,7 +31,7 @@
 		val res = createWithAllFields()
 		val savedRes = repository.save(res)
 
-		val result = super.getById(url, savedRes.identity.id!!)
+		val result = super.getById(url, savedRes.id!!)
 		resourceAsserts(savedRes, result)
 	}
 {{/vendorExtensions.isGetMethod}}
@@ -57,11 +57,12 @@
 	fun `{{vendorExtensions.operationMethodName}} with required fields`() {
 		val res = createWithRequiredFields()
 		val savedRes = repository.save(res)
-
+		{{#testModel.vendorExtensions.hasIdentity}}
 		savedRes.identity.name = "new identity"
 		savedRes.identity.description = "new description"
+		{{/testModel.vendorExtensions.hasIdentity}}
 
-		val result = super.update(url, savedRes.identity.id!!, savedRes)
+		val result = super.update(url, savedRes.id!!, savedRes)
 		resourceAsserts(savedRes, result)
 	}
 
@@ -69,11 +70,12 @@
 	fun `{{vendorExtensions.operationMethodName}} with all fields`() {
 		val res = createWithAllFields()
 		val savedRes = repository.save(res)
-
+		{{#testModel.vendorExtensions.hasIdentity}}
 		savedRes.identity.name = "new identity"
 		savedRes.identity.description = "new description"
+		{{/testModel.vendorExtensions.hasIdentity}}
 
-		val result = super.update(url, savedRes.identity.id!!, savedRes)
+		val result = super.update(url, savedRes.id!!, savedRes)
 		resourceAsserts(savedRes, result)
 	}
 {{/vendorExtensions.isPutMethod}}
@@ -82,11 +84,12 @@
 	fun `{{vendorExtensions.operationMethodName}} with all fields`() {
 		val res = createWithAllFields()
 		val savedRes = repository.save(res)
-
+		{{#testModel.vendorExtensions.hasIdentity}}
 		savedRes.identity.name = "new identity"
 		savedRes.identity.description = "new description"
+		{{/testModel.vendorExtensions.hasIdentity}}
 
-		val result = super.update(url, savedRes.identity.id!!, savedRes)
+		val result = super.update(url, savedRes.id!!, savedRes)
 		resourceAsserts(savedRes, result)
 	}
 {{/vendorExtensions.isPatchMethod}}
@@ -96,9 +99,10 @@
 		val res = createWithRequiredFields()
 		val savedRes = repository.save(res)
 
-		val result = super.delete(url, savedRes.identity.id!!)
-
+		val result = super.delete(url, savedRes.id!!)
+		{{#testModel.vendorExtensions.hasEntity}}
 		savedRes.entity.state = "deleted"
+		{{/testModel.vendorExtensions.hasEntity}}
 		resourceAsserts(savedRes, result)
 	}
 {{/vendorExtensions.isDeleteMethod}}

--- a/codegen-cli/src/main/resources/kotlin-codegen/common/src/main/kotlin/controller/AbstractController.kt.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/common/src/main/kotlin/controller/AbstractController.kt.mustache
@@ -63,7 +63,12 @@ abstract class AbstractController<E: BaseResource, S: CommonService<E>>(val  ser
 
 	override fun getById(parentId: String, id: String): ResponseEntity<E> {
 		val domain = service.getById(id) ?: throw ResourceNotFoundException()
+		{{#hasEntityBlocks}}
 		Assert.isTrue(parentId == domain.entity.parent?.id, "parent $parentId is not valid")
+		{{/hasEntityBlocks}}
+		{{^hasEntityBlocks}}
+		//TODO: should assert parent id here
+		{{/hasEntityBlocks}}
 		return ResponseEntity(domain, HttpStatus.OK)
 	}
 
@@ -88,7 +93,9 @@ abstract class AbstractController<E: BaseResource, S: CommonService<E>>(val  ser
 	override fun saveAll(parentId: String, domains: List<E>): List<E> {
 		domains.forEach {
 			validateParent(it, parentId)
+			{{#hasIentityBlocks}}
 			it.id = it.identity.id
+			{{/hasIentityBlocks}}
 		}
 		return service.saveAll(domains)
 	}
@@ -109,9 +116,14 @@ abstract class AbstractController<E: BaseResource, S: CommonService<E>>(val  ser
 	}
 
 	private fun validateParent(domain: E, parentId: String) {
+		{{#hasEntityBlocks}}
 		Assert.notNull(domain.entity.parent, "parent can not be empty")
 		Assert.notNull(domain.entity.parent?.id, "parent id is required")
 		Assert.isTrue(parentId == domain.entity.parent?.id, "parent $parentId is not valid")
+		{{/hasEntityBlocks}}
+		{{^hasEntityBlocks}}
+		//TODO: should check parent id here
+		{{/hasEntityBlocks}}
 	}
 
 	private fun getSearchCriteria(query: String?, parentId: String): String {

--- a/codegen-cli/src/main/resources/kotlin-codegen/common/src/main/kotlin/domain/commonPojoentity.kt.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/common/src/main/kotlin/domain/commonPojoentity.kt.mustache
@@ -6,13 +6,18 @@
 */
 {{>generatedAnnotation}}
 {{^vendorExtensions.isEmbeddable}}
+{{^vendorExtensions.isSuperclass}}
 @Entity
 @Table(name = "{{vendorExtensions.tableName}}")
+{{/vendorExtensions.isSuperclass}}
 {{/vendorExtensions.isEmbeddable}}
 {{#vendorExtensions.isEmbeddable}}
 @Embeddable
 {{/vendorExtensions.isEmbeddable}}
-data class {{classname}}(
+{{#vendorExtensions.isSuperclass}}
+@MappedSuperclass
+{{/vendorExtensions.isSuperclass}}
+{{#vendorExtensions.isSuperclass}}open{{/vendorExtensions.isSuperclass}}{{^vendorExtensions.isSuperclass}}data{{/vendorExtensions.isSuperclass}} class {{classname}}(
 {{#vendorExtensions.addIdVar}}
 
 	var id: String,

--- a/codegen-cli/src/main/resources/kotlin-codegen/common/src/main/kotlin/service/AbstractService.kt.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/common/src/main/kotlin/service/AbstractService.kt.mustache
@@ -13,31 +13,41 @@ import java.util.*
 
 abstract class AbstractService<E: BaseResource, R: CommonRepository<E>>(protected val repository: R): CommonService<E> {
 
-    private fun BaseResource.setDeleted() {
-        this.entity.state = "deleted"
-    }
-
-    private fun BaseResource?.isDeleted(): Boolean {
-        return this != null && this.entity.state == "deleted"
-    }
-
-    override fun save(domain: E): E {
-        return repository.save(domain)
+	private fun BaseResource.setDeleted() {
+		{{#hasEntityBlocks}}
+		this.entity.state = "deleted"
+		{{/hasEntityBlocks}}
+		{{^hasEntityBlocks}}
+		//TODO: soft delete function add here
+		{{/hasEntityBlocks}}
 	}
 
-    override fun delete(domain: E) {
-        domain.setDeleted()
+	private fun BaseResource?.isDeleted(): Boolean {
+		{{#hasEntityBlocks}}
+		return this != null && this.entity.state == "deleted"
+		{{/hasEntityBlocks}}
+		{{^hasEntityBlocks}}
+			return false //TODO: return delete property here
+		{{/hasEntityBlocks}}
+	}
+
+	override fun save(domain: E): E {
+		return repository.save(domain)
+	}
+
+	override fun delete(domain: E) {
+		domain.setDeleted()
 		save(domain)
 	}
 
-    override fun getById(id: String): E? {
-        val domain: E? = repository.findByIdOrNull(id)
-        return if (!domain.isDeleted()) domain else null
-    }
+	override fun getById(id: String): E? {
+		val domain: E? = repository.findByIdOrNull(id)
+		return if (!domain.isDeleted()) domain else null
+	}
 
-    override fun update(domain: E): E {
-        return repository.save(domain)
-    }
+	override fun update(domain: E): E {
+		return repository.save(domain)
+	}
 
 	override fun getAll(pageable: Pageable, query: String?): Page<E> {
 		return if (query.isNullOrBlank()) {
@@ -47,14 +57,14 @@ abstract class AbstractService<E: BaseResource, R: CommonRepository<E>>(protecte
 		}
 	}
 
-    override fun saveAll(domains: List<E>): List<E> {
-        return repository.saveAll(domains)
-    }
+	override fun saveAll(domains: List<E>): List<E> {
+		return repository.saveAll(domains)
+	}
 
-    override fun deleteAll(domains: List<E>) {
-        domains.forEach { it.setDeleted() }
-        saveAll(domains)
-    }
+	override fun deleteAll(domains: List<E>) {
+		domains.forEach { it.setDeleted() }
+		saveAll(domains)
+	}
 
 	override fun getByIds(ids: List<String>): List<E> {
 		return repository.findAllById(ids).filter{ !it.isDeleted() }
@@ -67,6 +77,6 @@ abstract class AbstractService<E: BaseResource, R: CommonRepository<E>>(protecte
 	private fun doGetAll(pageable: Pageable, query: String): Page<E> {
 		val rootNode: Node = RSQLParser().parse("entity.state!=deleted;$query")
 		val spec: Specification<E> = rootNode.accept(JpaRsqlVisitor())
-		return repository.findAll(spec,pageable)
+		return repository.findAll(spec, pageable)
 	}
 }

--- a/codegen-cli/src/main/resources/kotlin-codegen/common/src/test/kotlin/controller/AbstractIntegrationTest.kt.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/common/src/test/kotlin/controller/AbstractIntegrationTest.kt.mustache
@@ -135,6 +135,11 @@ abstract class AbstractIntegrationTest<E : BaseResource> : CommonIntegrationTest
 	}
 
 	fun findIdentityId(result: MvcResult): String {
+	{{#vendorExtensions.hasIdentity}}
 		return getValue(result, "$.identity.id")
+	{{/vendorExtensions.hasIdentity}}
+	{{^vendorExtensions.hasIdentity}}
+		return getValue(result, "$.id")
+	{{/vendorExtensions.hasIdentity}}
 	}
 }

--- a/codegen-cli/src/test/java/pro/bilous/codegen/process/FromModelProcessorTest.kt
+++ b/codegen-cli/src/test/java/pro/bilous/codegen/process/FromModelProcessorTest.kt
@@ -1,0 +1,98 @@
+package pro.bilous.codegen.process
+
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.openapitools.codegen.CodegenModel
+import org.openapitools.codegen.CodegenProperty
+import pro.bilous.codegen.process.models.IModelStrategyResolver
+import pro.bilous.codegen.process.models.ModelStrategyResolver
+
+internal class FromModelProcessorTest {
+
+	@Test
+	fun `should change enum classname`() {
+		val processor = FromModelProcessor(mock())
+		val model = CodegenModel().apply {
+			isEnum = true
+			classname = "AccountTypeEnum"
+			name = "AccountType"
+		}
+		processor.fixEnumName(model)
+		assertEquals("AccountType", model.classname)
+	}
+
+	@Test
+	fun `should not change not enum classname`() {
+		val processor = FromModelProcessor(mock())
+		val model = CodegenModel().apply {
+			isEnum = false
+			classname = "AccountTypeBody"
+			name = "AccountType"
+		}
+		processor.fixEnumName(model)
+		assertEquals("AccountTypeBody", model.classname)
+	}
+
+	@Test
+	fun `should remove vars started with _ or #`() {
+		val processor = FromModelProcessor(mock())
+		val model = CodegenModel().apply {
+			name = "Account"
+			vars = listOf(
+				CodegenProperty().apply { name = "_required" },
+				CodegenProperty().apply { name = "#firstName" },
+				CodegenProperty().apply { name = "fullName" }
+			)
+		}
+		processor.removeIgnoredFields(model)
+		assertEquals(1, model.vars.size)
+		assertEquals("fullName", model.vars.first().name)
+	}
+
+	@Test
+	fun `should fix required fields with "null" default value`() {
+		val processor = FromModelProcessor(mock())
+		val model = CodegenModel().apply {
+			name = "Account"
+			vars = listOf(
+				CodegenProperty().apply {
+					required = true
+					name = "required"
+					defaultValue = "null"
+				}
+			)
+		}
+		processor.fixRequiredFieldsDefaultValue(model)
+
+		assertNull(model.vars.first().defaultValue)
+	}
+
+	@Test
+	fun `should not fix non-required fields with "null" default value`() {
+		val processor = FromModelProcessor(mock())
+		val model = CodegenModel().apply {
+			name = "Account"
+			vars = listOf(CodegenProperty().apply { defaultValue = "null" })
+		}
+		processor.fixRequiredFieldsDefaultValue(model)
+		assertEquals("null", model.vars.first().defaultValue)
+	}
+
+	@Test
+	fun `should apply strategy resolver to model`() {
+		val processor = FromModelProcessor(mock())
+
+		val resolver: IModelStrategyResolver = mock()
+		val testArgs = ModelStrategyResolver.Args()
+		whenever(resolver.buildArgs()).thenReturn(testArgs)
+
+		processor.applyStrategyResolver(resolver)
+
+		verify(resolver).resolveParent(testArgs)
+		verify(resolver).cleanupImports()
+		verify(resolver).addExtensions(testArgs)
+	}
+}

--- a/codegen-cli/src/test/java/pro/bilous/codegen/process/models/ModelStrategyResolverTest.kt
+++ b/codegen-cli/src/test/java/pro/bilous/codegen/process/models/ModelStrategyResolverTest.kt
@@ -1,0 +1,181 @@
+package pro.bilous.codegen.process.models
+
+import org.junit.jupiter.api.Test
+import org.openapitools.codegen.CodegenModel
+import org.openapitools.codegen.CodegenProperty
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+internal class ModelStrategyResolverTest {
+
+	@Test
+	fun `should build args with all false`() {
+		val model = CodegenModel()
+		val resolver = ModelStrategyResolver(model)
+		val args = resolver.buildArgs()
+
+		assertFalse(args.hasEntity)
+		assertFalse(args.hasId)
+		assertFalse(args.hasExtends)
+		assertFalse(args.hasIdentity)
+	}
+
+	@Test
+	fun `should build args with hasIdentity && hasExtends = true`() {
+		val model = CodegenModel().apply {
+			name = "Account"
+			vars = listOf(
+				CodegenProperty().apply { name = "identity" },
+				CodegenProperty().apply { name = "entity" }
+			)
+		}
+		val resolver = ModelStrategyResolver(model)
+		val args = resolver.buildArgs()
+
+		assertTrue(args.hasIdentity)
+		assertTrue(args.hasEntity)
+		assertFalse(args.hasId)
+		assertFalse(args.hasExtends)
+	}
+
+	@Test
+	fun `should build args with hasExtends = true`() {
+		val model = CodegenModel().apply {
+			name = "Account"
+			requiredVars = listOf(CodegenProperty().apply {
+				name = "_extends"
+			})
+		}
+		val resolver = ModelStrategyResolver(model)
+		val args = resolver.buildArgs()
+
+		assertFalse(args.hasIdentity)
+		assertFalse(args.hasEntity)
+		assertFalse(args.hasId)
+		assertTrue(args.hasExtends)
+	}
+
+
+	@Test
+	fun `should build args with hasId = true`() {
+		val model = CodegenModel().apply {
+			name = "Account"
+			vars = listOf(CodegenProperty().apply {
+				name = "id"
+			})
+		}
+		val resolver = ModelStrategyResolver(model)
+		val args = resolver.buildArgs()
+
+		assertFalse(args.hasIdentity)
+		assertFalse(args.hasEntity)
+		assertTrue(args.hasId)
+		assertFalse(args.hasExtends)
+	}
+
+	@Test
+	fun `should cleanup imports`() {
+		val model = CodegenModel().apply {
+			imports = setOf("ApiModel", "JsonProperty", "Account")
+		}
+		val resolver = ModelStrategyResolver(model)
+		resolver.cleanupImports()
+		assertEquals(1, model.imports.size)
+		assertEquals("Account", model.imports.first())
+	}
+
+	@Test
+	fun `should add extensions to model when all agrs false`() {
+		val model = CodegenModel().apply {
+			name = "AccountParty"
+		}
+		val resolver = ModelStrategyResolver(model)
+		val testArgs = ModelStrategyResolver.Args()
+		resolver.addExtensions(testArgs)
+
+		assertFalse(model.vendorExtensions.containsKey("hasTableEntity"))
+		assertEquals("account_party", model.vendorExtensions["tableName"])
+		assertTrue(model.vendorExtensions["isEmbeddable"] as Boolean)
+		assertFalse(model.vendorExtensions["addIdVar"] as Boolean)
+		assertFalse(model.vendorExtensions["isSuperclass"] as Boolean)
+		assertFalse(model.vendorExtensions["hasIdentity"] as Boolean)
+		assertFalse(model.vendorExtensions["hasEntity"] as Boolean)
+	}
+
+	@Test
+	fun `should add extensions to model when identity & entity args`() {
+		val model = CodegenModel().apply {
+			name = "BaseResource"
+		}
+		val resolver = ModelStrategyResolver(model)
+		val testArgs = ModelStrategyResolver.Args(hasIdentity = true, hasEntity = true)
+		resolver.addExtensions(testArgs)
+
+		assertFalse(model.vendorExtensions.containsKey("hasTableEntity"))
+		assertFalse(model.vendorExtensions["isEmbeddable"] as Boolean)
+		assertTrue(model.vendorExtensions["isSuperclass"] as Boolean)
+		assertTrue(model.vendorExtensions["hasIdentity"] as Boolean)
+		assertTrue(model.vendorExtensions["hasEntity"] as Boolean)
+	}
+
+	@Test
+	fun `should add parent for model with Entity`() {
+		val model = CodegenModel().apply {
+			name = "Account"
+		}
+		val resolver = ModelStrategyResolver(model)
+		val testArgs = ModelStrategyResolver.Args(hasEntity = true)
+		resolver.resolveParent(testArgs)
+
+		assertEquals("BaseResource()", model.parent)
+		assertTrue(model.imports.contains("BaseResource"))
+		assertTrue(model.vendorExtensions["hasTableEntity"] as Boolean)
+	}
+
+	@Test
+	fun `should add parent for model with Id`() {
+		val model = CodegenModel().apply {
+			name = "Account"
+		}
+		val resolver = ModelStrategyResolver(model)
+		val testArgs = ModelStrategyResolver.Args(hasId = true)
+		resolver.resolveParent(testArgs)
+
+		assertEquals("BaseDomain()", model.parent)
+		assertTrue(model.imports.contains("BaseDomain"))
+		assertFalse(model.vendorExtensions.containsKey("hasTableEntity"))
+	}
+
+	@Test
+	fun `should add parent for model with Identity`() {
+		val model = CodegenModel().apply {
+			name = "Account"
+		}
+		val resolver = ModelStrategyResolver(model)
+		val testArgs = ModelStrategyResolver.Args(hasIdentity = true)
+		resolver.resolveParent(testArgs)
+
+		assertEquals("BaseDomain()", model.parent)
+		assertTrue(model.imports.contains("BaseDomain"))
+		assertFalse(model.vendorExtensions.containsKey("hasTableEntity"))
+	}
+
+	@Test
+	fun `should add parent for model with extends`() {
+		val model = CodegenModel().apply {
+			name = "Account"
+			requiredVars = listOf(CodegenProperty().apply {
+				name = "_extends"
+				complexType = "BaseResource"
+			})
+		}
+		val resolver = ModelStrategyResolver(model)
+		val testArgs = ModelStrategyResolver.Args(hasExtends = true)
+		resolver.resolveParent(testArgs)
+
+		assertEquals("BaseResource()", model.parent)
+		assertTrue(model.imports.contains("BaseResource"))
+		assertFalse(model.vendorExtensions.containsKey("hasTableEntity"))
+	}
+}


### PR DESCRIPTION
Support extends functionality in codegen and templates, simply add required filed with name `extends` into the DifHub metadata to activate it.
Note: extens can not be used together with `identity`, `entity` fields for now
Massive refactoring for the model strategies
Additional unit tests to cover existing functionality