### PR TITLE
#44 fixed absence of [columnDefinition = "json"] for embedded fields …

### DIFF
--- a/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/main/kotlin/domain/pojoentity.kt.mustache
+++ b/codegen-cli/src/main/resources/kotlin-codegen/app-module/src/main/kotlin/domain/pojoentity.kt.mustache
@@ -47,7 +47,7 @@ data class {{classname}}(
 				{{/vendorExtensions.embeddedComponent}}
 			{{/vendorExtensions.isEmbedded}}
 			{{^vendorExtensions.isEmbedded}}
-		AttributeOverride(name = "{{name}}", column = Column(name = "{{vendorExtensions.embeddedColumnName}}")),
+		AttributeOverride(name = "{{name}}", column = Column(name = "{{vendorExtensions.embeddedColumnName}}"{{#vendorExtensions.hasJsonType}}, columnDefinition = "json"{{/vendorExtensions.hasJsonType}})),
 			{{/vendorExtensions.isEmbedded}}
 		{{/vars}}
 	)


### PR DESCRIPTION
…with JSON type in case when it is on first level of nesting.

Now **_columnDefinition = "json"_** is set when _**vendorExtensions.hasJsonType**_ for all cases of **_vendorExtensions.isEmbedded_** for **_vendorExtensions.embeddedComponent_**